### PR TITLE
feat: add single option for snowflake to s3 task

### DIFF
--- a/edx_prefectutils/__init__.py
+++ b/edx_prefectutils/__init__.py
@@ -2,4 +2,4 @@
 Top-level package for edx-prefectutils.
 """
 
-__version__ = '2.2.1'
+__version__ = '2.2.2'

--- a/edx_prefectutils/snowflake.py
+++ b/edx_prefectutils/snowflake.py
@@ -422,6 +422,7 @@ def export_snowflake_table_to_s3(
     escape_unenclosed_field: str = '\\\\',
     null_marker: str = 'NULL',
     overwrite: bool = True,
+    single: bool = True,
 ):
 
     """
@@ -445,6 +446,7 @@ def export_snowflake_table_to_s3(
               field values only. Defaults to snowflake default `\\`.
       null_marker (str, optional): String used to convert SQL NULL. Defaults to `NULL`.
       overwrite (bool, optional): Whether to overwrite existing data in S3. Defaults to `TRUE`.
+      single (bool, optional): Whether to generate a single file in S3. Defaults to `TRUE`.
     """
     logger = get_logger()
 
@@ -468,6 +470,7 @@ def export_snowflake_table_to_s3(
             COMPRESSION = NONE
             )
             OVERWRITE={overwrite}
+            SINGLE={single}
     """.format(
         export_path=export_path,
         table=table_name,
@@ -477,6 +480,7 @@ def export_snowflake_table_to_s3(
         escape_unenclosed_field=escape_unenclosed_field,
         null_marker=null_marker,
         overwrite=overwrite,
+        single=single
     )
     logger.info(query)
     cursor = sf_connection.cursor()

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -321,7 +321,7 @@ def test_export_snowflake_table_to_s3_overwrite(mock_sf_connection):  # noqa: F8
 
     mock_cursor.execute.assert_has_calls(
         [
-            mock.call("\n        COPY INTO 's3://edx-test/test/test_database-test_schema-test_table/'\n            FROM test_database.test_schema.test_table\n            STORAGE_INTEGRATION = test_storage_integration\n            FILE_FORMAT = ( TYPE = CSV EMPTY_FIELD_AS_NULL = FALSE\n            FIELD_DELIMITER = ',' FIELD_OPTIONALLY_ENCLOSED_BY = 'NONE'\n            ESCAPE_UNENCLOSED_FIELD = '\\\\'\n            NULL_IF = ( 'NULL' )\n            COMPRESSION = NONE\n            )\n            OVERWRITE=True\n    "),  # noqa
+            mock.call("\n        COPY INTO 's3://edx-test/test/test_database-test_schema-test_table/'\n            FROM test_database.test_schema.test_table\n            STORAGE_INTEGRATION = test_storage_integration\n            FILE_FORMAT = ( TYPE = CSV EMPTY_FIELD_AS_NULL = FALSE\n            FIELD_DELIMITER = ',' FIELD_OPTIONALLY_ENCLOSED_BY = 'NONE'\n            ESCAPE_UNENCLOSED_FIELD = '\\\\'\n            NULL_IF = ( 'NULL' )\n            COMPRESSION = NONE\n            )\n            OVERWRITE=True\n            SINGLE=True\n    "),  # noqa
         ]
     )
 
@@ -346,7 +346,7 @@ def test_export_snowflake_table_to_s3_no_overwrite(mock_sf_connection):  # noqa:
 
     mock_cursor.execute.assert_has_calls(
         [
-            mock.call("\n        COPY INTO 's3://edx-test/test/test_database-test_schema-test_table/'\n            FROM test_database.test_schema.test_table\n            STORAGE_INTEGRATION = test_storage_integration\n            FILE_FORMAT = ( TYPE = CSV EMPTY_FIELD_AS_NULL = FALSE\n            FIELD_DELIMITER = ',' FIELD_OPTIONALLY_ENCLOSED_BY = 'NONE'\n            ESCAPE_UNENCLOSED_FIELD = '\\\\'\n            NULL_IF = ( 'NULL' )\n            COMPRESSION = NONE\n            )\n            OVERWRITE=False\n    "),  # noqa
+            mock.call("\n        COPY INTO 's3://edx-test/test/test_database-test_schema-test_table/'\n            FROM test_database.test_schema.test_table\n            STORAGE_INTEGRATION = test_storage_integration\n            FILE_FORMAT = ( TYPE = CSV EMPTY_FIELD_AS_NULL = FALSE\n            FIELD_DELIMITER = ',' FIELD_OPTIONALLY_ENCLOSED_BY = 'NONE'\n            ESCAPE_UNENCLOSED_FIELD = '\\\\'\n            NULL_IF = ( 'NULL' )\n            COMPRESSION = NONE\n            )\n            OVERWRITE=False\n            SINGLE=True\n    "),  # noqa
         ]
     )
 


### PR DESCRIPTION
Single option should be added to snowflake copy command to allow users of this task to specify whether or not they want one or multiple files in S3. See more on the option here: https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html#copy-options-copyoptions