### PR TITLE
feat: use None to omit some snowflake copy into clauses

### DIFF
--- a/edx_prefectutils/__init__.py
+++ b/edx_prefectutils/__init__.py
@@ -2,4 +2,4 @@
 Top-level package for edx-prefectutils.
 """
 
-__version__ = '2.2.7'
+__version__ = '2.3.0'


### PR DESCRIPTION
this lets us use the snowflake default for these behaviors without
having to echo the snowflake default here

switched these args to None unless provided because we usually want
the default

related to MST-1333