### PR TITLE
temp: add logging to help investigate intermittent import failure

### DIFF
--- a/edx_prefectutils/__init__.py
+++ b/edx_prefectutils/__init__.py
@@ -2,4 +2,4 @@
 Top-level package for edx-prefectutils.
 """
 
-__version__ = '2.3.1'
+__version__ = '2.3.2'

--- a/edx_prefectutils/snowflake.py
+++ b/edx_prefectutils/snowflake.py
@@ -539,6 +539,12 @@ def export_snowflake_table_to_s3(
                 ]
             }
 
+            logger.info(
+                'Uploading manifest file to s3, containing urls %(urls)s',
+                {
+                    "urls": s3_file_paths,
+                }
+            )
             s3.S3Upload(bucket=export_bucket).run(
                 json.dumps(manifest_file_content),
                 key=s3_manifest_file_prefix


### PR DESCRIPTION
specifically we're seeing these failures for course_activity_weekly

We see error messages like ```1815 (HY000): Internal error: No valid URIs specified in manifest``` and

```
Task 'export_snowflake_table_to_mysql_wrapper[0]': Exception encountered during task execution!
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/mysql/connector/connection_cext.py", line 523, in cmd_query
    self._cmysql.query(query,
_mysql_connector.MySQLInterfaceError: Internal error: No valid URIs specified in manifest

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/prefect/engine/task_runner.py", line 861, in get_task_run_state
    value = prefect.utilities.executors.run_task_with_timeout(
  File "/usr/local/lib/python3.8/site-packages/prefect/utilities/executors.py", line 327, in run_task_with_timeout
    return task.run(*args, **kwargs)  # type: ignore
  File "load_insights_tables_from_snowflake_to_aurora.py", line 72, in export_snowflake_table_to_mysql_wrapper
  File "/usr/local/lib/python3.8/site-packages/edx_prefectutils/mysql.py", line 168, in load_s3_data_to_mysql
    connection.cursor().execute(query)
  File "/usr/local/lib/python3.8/site-packages/mysql/connector/cursor_cext.py", line 269, in execute
    result = self._cnx.cmd_query(stmt, raw=self._raw,
  File "/usr/local/lib/python3.8/site-packages/mysql/connector/connection_cext.py", line 528, in cmd_query
    raise errors.get_mysql_exception(exc.errno, msg=exc.msg,
mysql.connector.errors.DatabaseError: 1815 (HY000): Internal error: No valid URIs specified in manifest
```

This is meant to shed some light on whether the manifest file is getting written with garbage in place of urls (as the error message from aurora would indicate) or whether the issue is maybe a timing issue between uploading to S3 and pulling down from S3.