### PR TITLE
build: push to pypi on tag push rather than on release publish

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,16 +1,16 @@
 name: Publish package to PyPi
 
 on:
-  # Triggers the workflow when release is published
-  release:
-    types: [published]
+  push:
+    tags:
+      - '*'
 
 jobs:
     push:
       runs-on: ubuntu-20.04
       steps:
         - name: Checkout
-          uses: actions/checkout@v1
+          uses: actions/checkout@v2
         - name: setup python
           uses: actions/setup-python@v2
           with:


### PR DESCRIPTION
it wasn't behaving as I expected it to, and our workflow template in
edx/.github does it this way.