### PR TITLE
Fix the cleanup_gcs_files function to convert HTTPIterator objects to lists

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,13 +32,13 @@ You can either clone the public repository:
 
 .. code-block:: console
 
-    $ git clone git://github.com/doctoryes/edx_prefectutils
+    $ git clone git://github.com/edx/edx-prefectutils
 
 Or download the `tarball`_:
 
 .. code-block:: console
 
-    $ curl -OJL https://github.com/doctoryes/edx_prefectutils/tarball/master
+    $ curl -OJL https://github.com/edx/edx-prefectutils/tarball/master
 
 Once you have a copy of the source, you can install it with:
 
@@ -47,5 +47,5 @@ Once you have a copy of the source, you can install it with:
     $ python setup.py install
 
 
-.. _Github repo: https://github.com/doctoryes/edx_prefectutils
-.. _tarball: https://github.com/doctoryes/edx_prefectutils/tarball/master
+.. _Github repo: https://github.com/edx/edx-prefectutils
+.. _tarball: https://github.com/edx/edx-prefectutils/tarball/master

--- a/edx_prefectutils/__init__.py
+++ b/edx_prefectutils/__init__.py
@@ -2,4 +2,4 @@
 Top-level package for edx-prefectutils.
 """
 
-__version__ = '2.3.6'
+__version__ = '2.3.7'

--- a/edx_prefectutils/bigquery.py
+++ b/edx_prefectutils/bigquery.py
@@ -26,7 +26,10 @@ def cleanup_gcs_files(gcp_credentials: dict, url: str, project: str):
     parsed_url = urlparse(url)
     bucket = gcs_client.get_bucket(parsed_url.netloc)
     prefix = parsed_url.path.lstrip("/")
-    blobs = bucket.list_blobs(prefix=prefix)
+    # The list function is needed because bucket.list_blobs returns an
+    # HTTPIterator object, which does not implement __len__.
+    # But bucket.delete_blobs expects an Iterable with __len__.
+    blobs = list(bucket.list_blobs(prefix=prefix))
     bucket.delete_blobs(blobs)
     return blobs
 

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,
-    url='https://github.com/doctoryes/edx_prefectutils',
+    url='https://github.com/edx/edx-prefectutils',
     version=VERSION,
     zip_safe=False,
 )


### PR DESCRIPTION
The `cleanup_gcs_files` function from `edx_prefectutils.bigquery` has been updated to convert the output of `bucket.list_blobs` to a `list`. There are also changes made to the docs and GitHub repository URLs.