### PR TITLE
build: remove especially unnecessary codecov dependency

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests in CI
 
-codecov                   # Code coverage reporting
 tox<4                     # Virtualenv management for tests, pinned due to following issue https://github.com/tox-dev/tox-pyenv/issues/22
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,8 +8,6 @@ certifi==2022.12.7
     # via requests
 charset-normalizer==3.0.1
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage==7.1.0
     # via codecov
 distlib==0.3.6


### PR DESCRIPTION
this repo doesn't appear to be uploading reports to codecov, so this yanked-from-pypi package is especially unnecessary here

see https://about.codecov.io/blog/message-regarding-the-pypi-package/ for context