### PR TITLE
fix: remove tox-battery package requirement

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,139 +5,138 @@
 #    make upgrade
 #
 asn1crypto==1.5.1
-    # via
-    #   oscrypto
-    #   snowflake-connector-python
+    # via snowflake-connector-python
 backoff==2.2.1
     # via -r requirements/base.in
-bcrypt==4.0.1
+bcrypt==4.1.1
     # via paramiko
-boto3==1.26.61
+boto3==1.33.11
     # via
     #   -r requirements/base.in
     #   prefect
-botocore==1.29.61
+botocore==1.33.11
     # via
     #   -r requirements/base.in
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.2
     # via google-auth
-certifi==2022.12.7
+certifi==2023.11.17
     # via
     #   requests
     #   snowflake-connector-python
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==2.1.1
+charset-normalizer==3.3.2
     # via
     #   requests
     #   snowflake-connector-python
-ciso8601==2.3.0
+ciso8601==2.3.1
     # via -r requirements/base.in
-click==8.1.3
+click==8.1.7
     # via
     #   dask
     #   distributed
     #   prefect
-cloudpickle==2.2.1
+cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
     #   prefect
-croniter==1.3.8
+croniter==2.0.1
     # via prefect
-cryptography==39.0.0
+cryptography==41.0.7
     # via
     #   paramiko
     #   pyopenssl
     #   snowflake-connector-python
-dask==2023.1.1
+dask==2023.3.1
     # via
     #   distributed
     #   prefect
-distributed==2023.1.1
+distributed==2023.3.1
     # via prefect
-docker==6.0.1
+docker==7.0.0
     # via prefect
-edx-opaque-keys==2.3.0
+edx-opaque-keys==2.5.1
     # via -r requirements/base.in
-filelock==3.9.0
+filelock==3.13.1
     # via snowflake-connector-python
-fsspec==2023.1.0
+fsspec==2023.12.1
     # via dask
-google-api-core[grpc]==2.11.0
+google-api-core[grpc]==2.15.0
     # via
+    #   google-api-core
     #   google-cloud-aiplatform
     #   google-cloud-bigquery
     #   google-cloud-core
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
     #   google-cloud-storage
-google-auth==2.16.0
+google-auth==2.25.2
     # via
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
     #   prefect
-google-cloud-aiplatform==1.21.0
+google-cloud-aiplatform==1.37.0
     # via prefect
-google-cloud-bigquery==3.4.2
+google-cloud-bigquery==3.13.0
     # via
     #   google-cloud-aiplatform
     #   prefect
-google-cloud-core==2.3.2
+google-cloud-core==2.4.1
     # via
     #   google-cloud-bigquery
     #   google-cloud-storage
-google-cloud-resource-manager==1.8.1
+google-cloud-resource-manager==1.11.0
     # via google-cloud-aiplatform
-google-cloud-secret-manager==2.15.1
+google-cloud-secret-manager==2.17.0
     # via prefect
-google-cloud-storage==2.7.0
+google-cloud-storage==2.13.0
     # via
     #   google-cloud-aiplatform
     #   prefect
 google-crc32c==1.5.0
-    # via google-resumable-media
-google-resumable-media==2.4.1
+    # via
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.6.0
     # via
     #   google-cloud-bigquery
     #   google-cloud-storage
-googleapis-common-protos[grpc]==1.58.0
+googleapis-common-protos[grpc]==1.62.0
     # via
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
 graphviz==0.20.1
     # via prefect
-grpc-google-iam-v1==0.12.6
+grpc-google-iam-v1==0.13.0
     # via
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
-grpcio==1.51.1
+grpcio==1.60.0
     # via
     #   google-api-core
     #   google-cloud-bigquery
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.51.1
+grpcio-status==1.60.0
     # via google-api-core
-heapdict==1.0.1
-    # via zict
-hvac==1.0.2
+hvac==2.0.0
     # via -r requirements/base.in
-idna==3.4
+idna==3.6
     # via
     #   requests
     #   snowflake-connector-python
 importlib-metadata==1.7.0
     # via -r requirements/base.in
-importlib-resources==5.10.2
+importlib-resources==6.1.1
     # via prefect
 jinja2==3.1.2
     # via distributed
@@ -149,25 +148,25 @@ locket==1.0.0
     # via
     #   distributed
     #   partd
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
-marshmallow==3.19.0
+marshmallow==3.20.1
     # via
     #   marshmallow-oneofschema
     #   prefect
 marshmallow-oneofschema==3.0.1
     # via prefect
-msgpack==1.0.4
+msgpack==1.0.7
     # via
     #   distributed
     #   prefect
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via prefect
 mysql-connector-python==8.0.21
     # via -r requirements/base.in
-oscrypto==1.3.0
-    # via snowflake-connector-python
-packaging==21.3
+numpy==1.24.4
+    # via shapely
+packaging==23.2
     # via
     #   dask
     #   distributed
@@ -176,23 +175,28 @@ packaging==21.3
     #   google-cloud-bigquery
     #   marshmallow
     #   prefect
-paramiko==3.0.0
+    #   snowflake-connector-python
+paramiko==3.3.1
     # via -r requirements/base.in
-partd==1.3.0
+partd==1.4.1
     # via dask
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
 pendulum==2.1.2
     # via prefect
+platformdirs==3.11.0
+    # via snowflake-connector-python
 prefect[aws,google,snowflake,viz]==1.4.1
-    # via -r requirements/base.in
-proto-plus==1.22.2
+    # via
+    #   -r requirements/base.in
+    #   prefect
+proto-plus==1.23.0
     # via
     #   google-cloud-aiplatform
     #   google-cloud-bigquery
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
-protobuf==4.21.12
+protobuf==4.25.1
     # via
     #   google-api-core
     #   google-cloud-aiplatform
@@ -204,31 +208,25 @@ protobuf==4.21.12
     #   grpcio-status
     #   mysql-connector-python
     #   proto-plus
-psutil==5.9.4
+psutil==5.9.6
     # via distributed
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.2.8
+pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
-    # via snowflake-connector-python
-pyhcl==0.4.4
-    # via hvac
-pyjwt==2.6.0
+pyjwt==2.8.0
     # via snowflake-connector-python
 pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via paramiko
-pyopenssl==23.0.0
+pyopenssl==23.3.0
     # via snowflake-connector-python
-pyparsing==3.0.9
-    # via packaging
-python-box==6.1.0
+python-box==7.1.1
     # via prefect
 python-dateutil==2.8.2
     # via
@@ -237,20 +235,21 @@ python-dateutil==2.8.2
     #   google-cloud-bigquery
     #   pendulum
     #   prefect
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via prefect
-pytz==2022.7.1
+pytz==2023.3.post1
     # via
+    #   croniter
     #   prefect
     #   snowflake-connector-python
 pytzdata==2020.1
     # via pendulum
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   dask
     #   distributed
     #   prefect
-requests==2.28.2
+requests==2.31.0
     # via
     #   docker
     #   google-api-core
@@ -261,38 +260,42 @@ requests==2.28.2
     #   snowflake-connector-python
 rsa==4.9
     # via google-auth
-s3transfer==0.6.0
+s3transfer==0.8.2
     # via boto3
-shapely==1.8.5.post1
+shapely==2.0.2
     # via google-cloud-aiplatform
 six==1.16.0
-    # via
-    #   google-auth
-    #   python-dateutil
-snowflake-connector-python==3.0.0
+    # via python-dateutil
+snowflake-connector-python==3.6.0
     # via prefect
 sortedcontainers==2.4.0
-    # via distributed
-stevedore==4.1.1
+    # via
+    #   distributed
+    #   snowflake-connector-python
+stevedore==5.1.0
     # via edx-opaque-keys
 tabulate==0.9.0
     # via prefect
-tblib==1.7.0
+tblib==3.0.0
     # via distributed
 text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via prefect
+tomlkit==0.12.3
+    # via snowflake-connector-python
 toolz==0.12.0
     # via
     #   dask
     #   distributed
     #   partd
-tornado==6.2
+tornado==6.4
     # via distributed
-typing-extensions==4.4.0
-    # via snowflake-connector-python
-urllib3==1.26.14
+typing-extensions==4.9.0
+    # via
+    #   edx-opaque-keys
+    #   snowflake-connector-python
+urllib3==1.26.18
     # via
     #   botocore
     #   distributed
@@ -300,14 +303,9 @@ urllib3==1.26.14
     #   prefect
     #   requests
     #   snowflake-connector-python
-websocket-client==1.5.0
-    # via docker
-zict==2.2.0
+zict==3.0.0
     # via distributed
-zipp==3.12.0
+zipp==3.17.0
     # via
     #   importlib-metadata
     #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,4 +1,3 @@
 # Requirements for running tests in CI
 
-tox<4                     # Virtualenv management for tests, pinned due to following issue https://github.com/tox-dev/tox-pyenv/issues/22
-tox-battery               # Makes tox aware of requirements file changes
+tox                     # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,41 +4,35 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.0.1
-    # via requests
-coverage==7.1.0
-    # via codecov
-distlib==0.3.6
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
+distlib==0.3.7
     # via virtualenv
-filelock==3.9.0
+filelock==3.13.1
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.2
+    # via
+    #   pyproject-api
+    #   tox
+platformdirs==4.1.0
+    # via
+    #   tox
+    #   virtualenv
+pluggy==1.3.0
     # via tox
-platformdirs==2.6.2
-    # via virtualenv
-pluggy==1.0.0
-    # via tox
-py==1.11.0
-    # via tox
-requests==2.28.2
-    # via codecov
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
-    # via tox
-tox==3.28.0
     # via
-    #   -r requirements/ci.in
-    #   tox-battery
-tox-battery==0.6.1
+    #   pyproject-api
+    #   tox
+tox==4.11.4
     # via -r requirements/ci.in
-urllib3==1.26.14
-    # via requests
-virtualenv==20.17.1
+virtualenv==20.25.0
     # via tox

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,20 +4,27 @@
 #
 #    make upgrade
 #
-build==0.10.0
+build==1.0.3
     # via pip-tools
-click==8.1.3
+click==8.1.7
     # via pip-tools
-packaging==23.0
+importlib-metadata==7.0.0
     # via build
-pip-tools==6.12.2
+packaging==23.2
+    # via build
+pip-tools==7.3.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
-    # via build
-wheel==0.38.4
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-hooks
+wheel==0.42.0
     # via pip-tools
+zipp==3.17.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,9 +4,11 @@
 #
 #    make upgrade
 #
-pip==23.0
+wheel==0.42.0
     # via -r requirements/pip.in
-setuptools==67.0.0
+
+# The following packages are considered to be unsafe in a requirements file:
+pip==23.3.1
     # via -r requirements/pip.in
-wheel==0.38.4
+setuptools==69.0.2
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,154 +6,160 @@
 #
 alabaster==0.7.13
     # via sphinx
-argh==0.26.2
+annotated-types==0.6.0
+    # via pydantic
+argh==0.30.4
     # via watchdog
 asn1crypto==1.5.1
     # via
     #   -r requirements/base.txt
-    #   oscrypto
     #   snowflake-connector-python
 atomicwrites==1.4.1
     # via pytest
-attrs==22.2.0
+attrs==23.1.0
     # via pytest
-babel==2.11.0
+babel==2.13.1
     # via sphinx
 backoff==2.2.1
     # via -r requirements/base.txt
-bcrypt==4.0.1
+bcrypt==4.1.1
     # via
     #   -r requirements/base.txt
     #   paramiko
-bleach==6.0.0
-    # via readme-renderer
-boto3==1.26.61
+boto3==1.33.11
     # via
     #   -r requirements/base.txt
     #   prefect
-botocore==1.29.61
+botocore==1.33.11
     # via
     #   -r requirements/base.txt
     #   boto3
     #   s3transfer
 bump2version==0.5.11
     # via -r requirements/test.in
-cachetools==5.3.0
+cachetools==5.3.2
     # via
     #   -r requirements/base.txt
     #   google-auth
-certifi==2022.12.7
+cerberus==1.3.5
+    # via plette
+certifi==2023.11.17
     # via
     #   -r requirements/base.txt
     #   requests
     #   snowflake-connector-python
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==2.1.1
+charset-normalizer==3.3.2
     # via
     #   -r requirements/base.txt
     #   requests
     #   snowflake-connector-python
-ciso8601==2.3.0
+ciso8601==2.3.1
     # via -r requirements/base.txt
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/base.txt
     #   dask
     #   distributed
     #   prefect
-cloudpickle==2.2.1
+cloudpickle==3.0.0
     # via
     #   -r requirements/base.txt
     #   dask
     #   distributed
     #   prefect
-croniter==1.3.8
+croniter==2.0.1
     # via
     #   -r requirements/base.txt
     #   prefect
-cryptography==39.0.0
+cryptography==41.0.7
     # via
     #   -r requirements/base.txt
     #   paramiko
     #   pyopenssl
     #   snowflake-connector-python
-dask==2023.1.1
+dask==2023.3.1
     # via
     #   -r requirements/base.txt
     #   distributed
     #   prefect
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/test.in
-distributed==2023.1.1
+distlib==0.3.7
+    # via requirementslib
+distributed==2023.3.1
     # via
     #   -r requirements/base.txt
     #   prefect
-docker==6.0.1
+docker==7.0.0
     # via
     #   -r requirements/base.txt
     #   prefect
-docutils==0.19
+docopt==0.6.2
+    # via pipreqs
+docutils==0.20.1
     # via
     #   readme-renderer
     #   sphinx
-edx-opaque-keys==2.3.0
+edx-opaque-keys==2.5.1
     # via -r requirements/base.txt
 entrypoints==0.3
     # via flake8
-filelock==3.9.0
+filelock==3.13.1
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
 flake8==3.7.8
     # via -r requirements/test.in
-fsspec==2023.1.0
+fsspec==2023.12.1
     # via
     #   -r requirements/base.txt
     #   dask
-google-api-core[grpc]==2.11.0
+google-api-core[grpc]==2.15.0
     # via
     #   -r requirements/base.txt
+    #   google-api-core
     #   google-cloud-aiplatform
     #   google-cloud-bigquery
     #   google-cloud-core
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
     #   google-cloud-storage
-google-auth==2.16.0
+google-auth==2.25.2
     # via
     #   -r requirements/base.txt
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
     #   prefect
-google-cloud-aiplatform==1.21.0
+google-cloud-aiplatform==1.37.0
     # via
     #   -r requirements/base.txt
     #   prefect
-google-cloud-bigquery==3.4.2
+google-cloud-bigquery==3.13.0
     # via
     #   -r requirements/base.txt
     #   google-cloud-aiplatform
     #   prefect
-google-cloud-core==2.3.2
+google-cloud-core==2.4.1
     # via
     #   -r requirements/base.txt
     #   google-cloud-bigquery
     #   google-cloud-storage
-google-cloud-resource-manager==1.8.1
+google-cloud-resource-manager==1.11.0
     # via
     #   -r requirements/base.txt
     #   google-cloud-aiplatform
-google-cloud-secret-manager==2.15.1
+google-cloud-secret-manager==2.17.0
     # via
     #   -r requirements/base.txt
     #   prefect
-google-cloud-storage==2.7.0
+google-cloud-storage==2.13.0
     # via
     #   -r requirements/base.txt
     #   google-cloud-aiplatform
@@ -161,28 +167,30 @@ google-cloud-storage==2.7.0
 google-crc32c==1.5.0
     # via
     #   -r requirements/base.txt
+    #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.4.1
+google-resumable-media==2.6.0
     # via
     #   -r requirements/base.txt
     #   google-cloud-bigquery
     #   google-cloud-storage
-googleapis-common-protos[grpc]==1.58.0
+googleapis-common-protos[grpc]==1.62.0
     # via
     #   -r requirements/base.txt
     #   google-api-core
+    #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
 graphviz==0.20.1
     # via
     #   -r requirements/base.txt
     #   prefect
-grpc-google-iam-v1==0.12.6
+grpc-google-iam-v1==0.13.0
     # via
     #   -r requirements/base.txt
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
-grpcio==1.51.1
+grpcio==1.60.0
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -190,19 +198,15 @@ grpcio==1.51.1
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.51.1
+grpcio-status==1.60.0
     # via
     #   -r requirements/base.txt
     #   google-api-core
-heapdict==1.0.1
-    # via
-    #   -r requirements/base.txt
-    #   zict
 httpretty==1.0.5
     # via -r requirements/test.in
-hvac==1.0.2
+hvac==2.0.0
     # via -r requirements/base.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/base.txt
     #   requests
@@ -213,11 +217,11 @@ importlib-metadata==1.7.0
     # via
     #   -r requirements/base.txt
     #   pytest
-importlib-resources==5.10.2
+importlib-resources==6.1.1
     # via
     #   -r requirements/base.txt
     #   prefect
-isort==5.12.0
+isort==5.13.0
     # via -r requirements/test.in
 jinja2==3.1.2
     # via
@@ -234,11 +238,11 @@ locket==1.0.0
     #   -r requirements/base.txt
     #   distributed
     #   partd
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/base.txt
     #   jinja2
-marshmallow==3.19.0
+marshmallow==3.20.1
     # via
     #   -r requirements/base.txt
     #   marshmallow-oneofschema
@@ -249,26 +253,28 @@ marshmallow-oneofschema==3.0.1
     #   prefect
 mccabe==0.6.1
     # via flake8
-mock==5.0.1
+mock==5.1.0
     # via -r requirements/test.in
-more-itertools==9.0.0
+more-itertools==10.1.0
     # via pytest
-msgpack==1.0.4
+msgpack==1.0.7
     # via
     #   -r requirements/base.txt
     #   distributed
     #   prefect
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via
     #   -r requirements/base.txt
     #   prefect
 mysql-connector-python==8.0.21
     # via -r requirements/base.txt
-oscrypto==1.3.0
+nh3==0.2.15
+    # via readme-renderer
+numpy==1.24.4
     # via
     #   -r requirements/base.txt
-    #   snowflake-connector-python
-packaging==21.3
+    #   shapely
+packaging==23.2
     # via
     #   -r requirements/base.txt
     #   dask
@@ -279,16 +285,17 @@ packaging==21.3
     #   marshmallow
     #   prefect
     #   pytest
+    #   snowflake-connector-python
     #   sphinx
-paramiko==3.0.0
+paramiko==3.3.1
     # via -r requirements/base.txt
-partd==1.3.0
+partd==1.4.1
     # via
     #   -r requirements/base.txt
     #   dask
 pathtools==0.1.2
     # via watchdog
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -296,20 +303,35 @@ pendulum==2.1.2
     # via
     #   -r requirements/base.txt
     #   prefect
+pep517==0.13.1
+    # via requirementslib
+pip-api==0.0.30
+    # via isort
+pipreqs==0.4.13
+    # via isort
 pkginfo==1.9.6
     # via twine
+platformdirs==3.11.0
+    # via
+    #   -r requirements/base.txt
+    #   requirementslib
+    #   snowflake-connector-python
+plette[validation]==0.4.4
+    # via requirementslib
 pluggy==0.13.1
     # via pytest
 prefect[aws,google,snowflake,viz]==1.4.1
-    # via -r requirements/base.txt
-proto-plus==1.22.2
+    # via
+    #   -r requirements/base.txt
+    #   prefect
+proto-plus==1.23.0
     # via
     #   -r requirements/base.txt
     #   google-cloud-aiplatform
     #   google-cloud-bigquery
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
-protobuf==4.21.12
+protobuf==4.25.1
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -322,18 +344,18 @@ protobuf==4.21.12
     #   grpcio-status
     #   mysql-connector-python
     #   proto-plus
-psutil==5.9.4
+psutil==5.9.6
     # via
     #   -r requirements/base.txt
     #   distributed
 py==1.11.0
     # via pytest
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   -r requirements/base.txt
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.2.8
+pyasn1-modules==0.3.0
     # via
     #   -r requirements/base.txt
     #   google-auth
@@ -343,21 +365,17 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.17
-    # via
-    #   -r requirements/base.txt
-    #   snowflake-connector-python
+pydantic==2.5.2
+    # via requirementslib
+pydantic-core==2.14.5
+    # via pydantic
 pyflakes==2.1.1
     # via flake8
-pygments==2.14.0
+pygments==2.17.2
     # via
     #   readme-renderer
     #   sphinx
-pyhcl==0.4.4
-    # via
-    #   -r requirements/base.txt
-    #   hvac
-pyjwt==2.6.0
+pyjwt==2.8.0
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
@@ -369,14 +387,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   paramiko
-pyopenssl==23.0.0
+pyopenssl==23.3.0
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
-pyparsing==3.0.9
-    # via
-    #   -r requirements/base.txt
-    #   packaging
 pytest==4.6.5
     # via
     #   -r requirements/test.in
@@ -385,7 +399,7 @@ pytest-mock==3.1.1
     # via -r requirements/test.in
 pytest-runner==5.1
     # via -r requirements/test.in
-python-box==6.1.0
+python-box==7.1.1
     # via
     #   -r requirements/base.txt
     #   prefect
@@ -397,30 +411,31 @@ python-dateutil==2.8.2
     #   google-cloud-bigquery
     #   pendulum
     #   prefect
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/base.txt
     #   prefect
-pytz==2022.7.1
+pytz==2023.3.post1
     # via
     #   -r requirements/base.txt
     #   babel
+    #   croniter
     #   prefect
     #   snowflake-connector-python
 pytzdata==2020.1
     # via
     #   -r requirements/base.txt
     #   pendulum
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements/base.txt
     #   dask
     #   distributed
     #   prefect
     #   watchdog
-readme-renderer==37.3
+readme-renderer==42.0
     # via twine
-requests==2.28.2
+requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   docker
@@ -430,34 +445,36 @@ requests==2.28.2
     #   hvac
     #   prefect
     #   requests-toolbelt
+    #   requirementslib
     #   snowflake-connector-python
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+    #   yarg
+requests-toolbelt==1.0.0
     # via twine
+requirementslib==3.0.0
+    # via isort
 rsa==4.9
     # via
     #   -r requirements/base.txt
     #   google-auth
-s3transfer==0.6.0
+s3transfer==0.8.2
     # via
     #   -r requirements/base.txt
     #   boto3
-shapely==1.8.5.post1
+shapely==2.0.2
     # via
     #   -r requirements/base.txt
     #   google-cloud-aiplatform
 six==1.16.0
     # via
     #   -r requirements/base.txt
-    #   bleach
-    #   google-auth
     #   pytest
     #   python-dateutil
     #   sphinx
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==3.0.0
+snowflake-connector-python==3.6.0
     # via
     #   -r requirements/base.txt
     #   prefect
@@ -465,13 +482,14 @@ sortedcontainers==2.4.0
     # via
     #   -r requirements/base.txt
     #   distributed
+    #   snowflake-connector-python
 sphinx==1.8.5
     # via -r requirements/test.in
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinxcontrib-websupport
 sphinxcontrib-websupport==1.2.4
     # via sphinx
-stevedore==4.1.1
+stevedore==5.1.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -479,7 +497,7 @@ tabulate==0.9.0
     # via
     #   -r requirements/base.txt
     #   prefect
-tblib==1.7.0
+tblib==3.0.0
     # via
     #   -r requirements/base.txt
     #   distributed
@@ -491,25 +509,37 @@ toml==0.10.2
     # via
     #   -r requirements/base.txt
     #   prefect
+tomli==2.0.1
+    # via pep517
+tomlkit==0.12.3
+    # via
+    #   -r requirements/base.txt
+    #   plette
+    #   requirementslib
+    #   snowflake-connector-python
 toolz==0.12.0
     # via
     #   -r requirements/base.txt
     #   dask
     #   distributed
     #   partd
-tornado==6.2
+tornado==6.4
     # via
     #   -r requirements/base.txt
     #   distributed
-tqdm==4.64.1
+tqdm==4.66.1
     # via twine
 twine==1.14.0
     # via -r requirements/test.in
-typing-extensions==4.4.0
+typing-extensions==4.9.0
     # via
     #   -r requirements/base.txt
+    #   annotated-types
+    #   edx-opaque-keys
+    #   pydantic
+    #   pydantic-core
     #   snowflake-connector-python
-urllib3==1.26.14
+urllib3==1.26.18
     # via
     #   -r requirements/base.txt
     #   botocore
@@ -520,25 +550,22 @@ urllib3==1.26.14
     #   snowflake-connector-python
 watchdog==0.9.0
     # via -r requirements/test.in
-wcwidth==0.2.6
+wcwidth==0.2.12
     # via pytest
-webencodings==0.5.1
-    # via bleach
-websocket-client==1.5.0
-    # via
-    #   -r requirements/base.txt
-    #   docker
 wheel==0.33.6
     # via -r requirements/test.in
-zict==2.2.0
+yarg==0.1.9
+    # via pipreqs
+zict==3.0.0
     # via
     #   -r requirements/base.txt
     #   distributed
-zipp==3.12.0
+zipp==3.17.0
     # via
     #   -r requirements/base.txt
     #   importlib-metadata
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools


### PR DESCRIPTION
## Description
- Removed `tox-battery` from package requirements since it is no longer needed with `tox v4`. 
- Updated `tox v4` after removing the constraint.