### PR TITLE
build: updated ubuntu version to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ['3.8']
         toxenv: [quality, py38]
 

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -20,7 +20,7 @@ jobs:
           run: pip install -r requirements/pip.txt
 
         - name: Install build tools
-          run: pip install --upgrade setuptools wheel
+          run: pip install --upgrade "setuptools>=65" "wheel>=0.38"
 
         - name: Build package
           run: python setup.py sdist bdist_wheel

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     push:
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
       steps:
         - name: Checkout
           uses: actions/checkout@v2

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -19,6 +19,9 @@ jobs:
         - name: Install pip
           run: pip install -r requirements/pip.txt
 
+        - name: Install build tools
+          run: pip install --upgrade setuptools wheel
+
         - name: Build package
           run: python setup.py sdist bdist_wheel
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,6 @@ replace = version='{new_version}'
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude = docs
 max-line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ setenv =
 deps =
     -r{toxinidir}/requirements/test.txt
 commands =
-    pip install -U pip
+    pip install -U pip setuptools wheel
     pytest --basetemp={envtmpdir}
 
 [testenv:quality]

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ allowlist_externals =
     touch
 deps =
     -r{toxinidir}/requirements/test.txt
+commands_pre =
+    pip install -U setuptools>=65 wheel>=0.38
 commands =
     touch tests/__init__.py
     flake8 edx_prefectutils tests

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ envlist = py38, quality
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-    setuptools>=65
-    wheel>=0.38
     -r{toxinidir}/requirements/test.txt
+commands_pre =
+    pip install -U setuptools>=65 wheel>=0.38
 commands =
     pytest --basetemp={envtmpdir}
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ envlist = py38, quality
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
+    setuptools>=65
+    wheel>=0.38
     -r{toxinidir}/requirements/test.txt
-commands_pre =
-    pip install -U setuptools>=65 wheel>=0.38
 commands =
     pytest --basetemp={envtmpdir}
 
@@ -18,9 +18,9 @@ allowlist_externals =
     rm
     touch
 deps =
+    setuptools>=65
+    wheel>=0.38
     -r{toxinidir}/requirements/test.txt
-commands_pre =
-    pip install -U setuptools>=65 wheel>=0.38
 commands =
     touch tests/__init__.py
     flake8 edx_prefectutils tests

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,10 @@ envlist = py38, quality
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
+    setuptools>=65
+    wheel>=0.38
     -r{toxinidir}/requirements/test.txt
 commands =
-    pip install -U pip setuptools wheel
     pytest --basetemp={envtmpdir}
 
 [testenv:quality]


### PR DESCRIPTION
# Description
Updating the latest version of ubuntu

# Ticket Reference
https://2u-internal.atlassian.net/browse/BOMS-285

Deprecated universal = 1 in setup.cfg - This setting for Python 2/3 universal wheels is obsolete and causes TypeError with modern wheel versions
